### PR TITLE
Remove old and useless handler and use Ansible module to set hostname

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,0 @@
-- name: Reload hostname
-  service: name=hostname state=restarted
-  when: ansible_distribution_version | version_compare('14.04', '<=')

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -1,8 +1,11 @@
+- name: Set hostname
+  hostname: 
+    name: "{{ inventory_hostname }}"
+
 - name: Creates /etc/hosts file
   template: src="../templates/hosts.j2" dest=/etc/hosts
 
-- name: Sets hostname
+- name: Sets hostname in /etc/hostname
   template:
     src: "../templates/hostname.j2" 
     dest: /etc/hostname
-

--- a/tasks/hosts.yml
+++ b/tasks/hosts.yml
@@ -5,5 +5,4 @@
   template:
     src: "../templates/hostname.j2" 
     dest: /etc/hostname
-  notify: Reload hostname
 


### PR DESCRIPTION
`version_compare` filter is a deprecated option since Ansible 2.5.
Handler is old and useless, so just remove them and use Ansible module to use `hostname`.

cc. @devops-works/admins 